### PR TITLE
Reorganize DOS integration routines

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Joseph Kleinhenz <kleinhenz.joseph@gmail.com>"]
 version = "0.5.0"
 
 [deps]
+Elliptic = "b305315f-e792-5b7a-8f41-49f472929428"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"

--- a/src/Keldysh.jl
+++ b/src/Keldysh.jl
@@ -15,6 +15,9 @@ export TimeGrid, TimeGridPoint, branch_bounds, integrate, step
 # TimeGF functions
 export TimeGF, TimeGFTranspose, jump
 
+# DOS functions
+export dos_integrator, flat_dos, gaussian_dos, bethe_dos, chain_dos, square_dos
+
 # generate_gf functions
 export gf_1level, dos2gf
 
@@ -25,6 +28,7 @@ include("branch.jl")
 include("contour.jl")
 include("time_grid.jl")
 include("time_gf.jl")
+include("dos.jl")
 include("generate_gf.jl")
 include("hdf5.jl")
 

--- a/src/dos.jl
+++ b/src/dos.jl
@@ -9,7 +9,7 @@ struct DOSSingularity
   position::Real
   # Asymptotic behavior of the DOS near the singularity, S_p(ω).
   # To be chosen such that \lim_{ω \to Ω_p} [D(ω) - S_p(ω)] = 0
-  asymptotics::Function
+  asymptotics
   # Integral of 'asymptotics' over ω\in[ω_{min};ω_{max}].
   integral
 end
@@ -30,7 +30,7 @@ struct SingularDOS
   ωmin::Real
   ωmax::Real
   # Regular part R(ω)
-  regular::Function
+  regular
   # List of singularities
   singularities::Vector{DOSSingularity}
 end

--- a/src/dos.jl
+++ b/src/dos.jl
@@ -1,0 +1,124 @@
+using QuadGK
+using Elliptic
+
+"""
+Descriptor of an integrable singularity in DOS
+"""
+struct DOSSingularity
+  # Position of the singularity, Ω_p.
+  position::Real
+  # Asymptotic behavior of the DOS near the singularity, S_p(ω).
+  # To be chosen such that \lim_{ω \to Ω_p} [D(ω) - S_p(ω)] = 0
+  asymptotics::Function
+  # Integral of 'asymptotics' over ω\in[ω_{min};ω_{max}].
+  integral::Real
+end
+
+"""
+  SingularDOS represents densities of states D(ω) according to
+  the following decomposition,
+
+  D(ω) = R(ω) + \\sum_{p=1}^P S_p(ω).
+
+  R(ω) is a smooth function on [ω_{min};ω_{max}], and the number P of
+  singular contributions S_p(ω) equals the number of integrable singularities
+  Ω_p of D(ω). Each term S_p(ω) is regular everywhere on
+  ω\\in[ω_{min};ω_{max}] except for its corresponding ω = Ω_p.
+"""
+struct SingularDOS
+  # Support limits
+  ωmin::Real
+  ωmax::Real
+  # Regular part R(ω)
+  regular::Function
+  # List of singularities
+  singularities::Vector{DOSSingularity}
+end
+
+"""Evaluate singular DOS at a given frequency"""
+function (dos::SingularDOS)(ω)
+  dos.regular(ω) + sum(s.asymptotics(ω) for s in dos.singularities)
+end
+
+"""
+Support limits of a DOS object
+"""
+dos_support_limits(dos) = (-Inf, Inf)
+dos_support_limits(dos::SingularDOS) = (dos.ωmin, dos.ωmax)
+
+"""Integrator for general DOS objects"""
+function dos_integrator(f, dos; atol=1e-10, rtol=1e-10, maxevals=10^9, order=21)
+  limits = dos_support_limits(dos)
+  integral, err = quadgk(ω -> f(ω) * dos(ω),
+                         limits[1], limits[2],
+                         atol=atol, rtol=rtol, maxevals=maxevals, order=order)
+  integral
+end
+
+"""Integrator for SingularDOS"""
+function dos_integrator(f, dos::SingularDOS; atol=1e-10, rtol=1e-10, maxevals=10^9, order=21)
+  limits = dos_support_limits(dos)
+  val = quadgk(ω -> f(ω) * dos.regular(ω),
+               limits[1], limits[2],
+               atol=atol, rtol=rtol, maxevals=maxevals, order=order)[1]
+  for s in dos.singularities
+    f_s = f(s.position)
+    val += quadgk(ω -> abs(ω - s.position) < eps() ? .0 : s.asymptotics(ω) * (f(ω) - f_s),
+                  limits[1], limits[2],
+                  atol=atol, rtol=rtol, maxevals=maxevals, order=order)[1]
+    val += f_s * s.integral
+  end
+  val
+end
+
+#
+# Factory functions
+#
+
+"""
+`flat_dos(;ν=1.0, D=5.0)`
+
+return flat band DOS with half-bandwith D and inverse cutoff width ν centered at zero
+"""
+flat_dos(; ν=1.0, D=5.0) = ω -> (1.0/π) / ((1 + exp(ν * (ω - D))) * (1 + exp(-ν * (ω + D))))
+
+"""
+`gaussian_dos(; ϵ=1.0, ν=1.0)`
+
+return normalized Gaussian DOS centered at ϵ with width ν
+"""
+gaussian_dos(; ϵ=1.0, ν=1.0) = ω -> (1.0 / (2 * sqrt(π * ν))) * exp(-((ω - ϵ)^2)/(4ν))
+
+"""
+`bethe_dos(; t=1.0)`
+
+return normalized DOS of a Bethe lattice with hopping constant t
+"""
+bethe_dos(; t=1.0) = SingularDOS(-2t, 2t,
+  ω -> begin
+    if ω == -2t || ω == 2t
+      -2 / (π*t)
+    else
+      x = ω / (2t)
+      (sqrt(1 - x*x) - sqrt(2 * (1 - x)) - sqrt(2 * (1 + x))) / (π*t)
+    end
+  end,
+  [
+    DOSSingularity(-2t, ω -> sqrt(2 * (1 + ω / (2t))) / (π*t), 16 / (3*π)),
+    DOSSingularity( 2t, ω -> sqrt(2 * (1 - ω / (2t))) / (π*t), 16 / (3*π))
+  ]
+)
+
+#"""
+#`chain_dos(; t=1.0)`
+#
+#return normalized DOS of a linear chain with hopping constant t
+#"""
+#chain_dos(; t=1.0) = (1.0 / (2 * π * t)) / sqrt(1 - (ω / (2t))^2)
+#
+#"""
+#`square_dos(; t=1.0)`
+#
+#return normalized DOS of a 2D square lattice with hopping constant t
+#"""
+#square_dos(; t=1.0) = (1.0 / (2 * π^2 * t)) * Elliptic.K(1 - (ω / (4t))^2)

--- a/src/generate_gf.jl
+++ b/src/generate_gf.jl
@@ -26,9 +26,7 @@ function dos2gf(dos, t1::BranchPoint, t2::BranchPoint; β, integrator = dos_inte
     return -1.0im * (2 * theta - 1) * integrator(f, dos)
 end
 
-function dos2gf(dos, grid::TimeGrid;
-                β=nothing, integrator=dos_integrator,
-                ωmin = -Inf, ωmax = Inf, singularities = Real[])
+function dos2gf(dos, grid::TimeGrid; β=nothing, integrator=dos_integrator)
   β = get_beta(grid, β)
   TimeGF(grid) do t1, t2
     dos2gf(dos, t1.val, t2.val, β=β, integrator=integrator)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -157,14 +157,14 @@ end
   end
 
   # Linear chain DOS
-  #let t=2.0, dos = Keldysh.chain_dos(t=t)
-  #  n = dos_integrator(ω -> 1, dos)
-  #  @test isapprox(n, 1.0, atol=1e-10, rtol=1e-10)
-  #end
+  let t=2.0, dos = Keldysh.chain_dos(t=t)
+    n = dos_integrator(ω -> 1, dos)
+    @test isapprox(n, 1.0, atol=1e-10, rtol=1e-10)
+  end
 
   # Square lattice DOS
-  #let t=2.0, dos = Keldysh.square_dos(t=t)
-  #  n = dos_integrator(ω -> 1, dos)
-  #  @test isapprox(n, 1.0, atol=1e-10, rtol=1e-10)
-  #end
+  let t=2.0, dos = Keldysh.square_dos(t=t)
+    n = dos_integrator(ω -> 1, dos)
+    @test isapprox(n, 1.0, atol=1e-10, rtol=1e-10)
+  end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -124,7 +124,7 @@ end
   let tmax = 1.0, β = 1.0, ν = 1/1000, ϵ = 2.0
     c = twist(Contour(full_contour, tmax=tmax, β=β))
     grid = TimeGrid(c, npts_real=51, npts_imag=51)
-    dos = ω -> Keldysh.gaussian_dos(ω, ν=ν, ϵ=ϵ)
+    dos = Keldysh.gaussian_dos(ν=ν, ϵ=ϵ)
 
     hyb1 = dos2gf(dos, grid)
     hyb2 = gf_1level(grid, ϵ=ϵ)
@@ -135,4 +135,36 @@ end
     # can't also supply β if it is part of the contour
     @test_throws AssertionError dos2gf(dos, grid, β = β)
   end
+end
+
+@testset "dos" begin
+  # Flat DOS
+  let ν=10, D=7.0, dos = Keldysh.flat_dos(ν=ν, D=D)
+    n = dos_integrator(ω -> 1, dos)
+    @test isapprox(n, (2D) / π, atol=1e-10, rtol=1e-10)
+  end
+
+  # Gaussian DOS
+  let ν = 2.0, ϵ = 1.0, dos = Keldysh.gaussian_dos(ν=ν, ϵ=ϵ)
+    n = dos_integrator(ω -> 1, dos)
+    @test isapprox(n, 1.0, atol=1e-10, rtol=1e-10)
+  end
+
+  # Bethe DOS
+  let t=2.0, dos = Keldysh.bethe_dos(t=t)
+    n = dos_integrator(ω -> 1, dos)
+    @test isapprox(n, 1.0, atol=1e-10, rtol=1e-10)
+  end
+
+  # Linear chain DOS
+  #let t=2.0, dos = Keldysh.chain_dos(t=t)
+  #  n = dos_integrator(ω -> 1, dos)
+  #  @test isapprox(n, 1.0, atol=1e-10, rtol=1e-10)
+  #end
+
+  # Square lattice DOS
+  #let t=2.0, dos = Keldysh.square_dos(t=t)
+  #  n = dos_integrator(ω -> 1, dos)
+  #  @test isapprox(n, 1.0, atol=1e-10, rtol=1e-10)
+  #end
 end


### PR DESCRIPTION
* DOS with integrable singularities can now be represented with a special struct `SingularDOS`.
* Added factory functions for Bethe lattice DOS, linear chain DOS and 2D square lattice DOS.