### PR TITLE
[contour] New function `get_ref()`

### DIFF
--- a/src/Keldysh.jl
+++ b/src/Keldysh.jl
@@ -10,7 +10,7 @@ export fermi
 export BranchEnum, forward_branch, backward_branch, imaginary_branch, BranchPoint, Branch
 
 # Contour functions
-export AbstractContour, FullContour, KeldyshContour, ImaginaryContour, twist, heaviside, nbranches
+export AbstractContour, FullContour, KeldyshContour, ImaginaryContour, twist, heaviside, nbranches, get_point, get_ref
 
 # TimeGrid functions
 export AbstractTimeGrid, FullTimeGrid, KeldyshTimeGrid, ImaginaryTimeGrid, TimeGridPoint, TimeDomain, integrate, realtimes, imagtimes

--- a/src/contour.jl
+++ b/src/contour.jl
@@ -52,6 +52,19 @@ end
 
 (c::AbstractContour)(ref::Real) = get_point(c, ref)
 
+function get_ref(c::AbstractContour, t::BranchPoint)
+  ref = 0
+  for b in c.branches
+      lb = length(b)
+      if t.domain == b.domain
+          return ref + (t.ref * lb)
+      else
+          ref += lb
+      end
+  end
+  @assert false
+end
+
 function twist(c::FullContour)
   n = nbranches(c)
   FullContour(ntuple(i -> c.branches[mod1(i+1,n)], n), c.tmax, c.β)

--- a/test/contour.jl
+++ b/test/contour.jl
@@ -53,4 +53,11 @@ using Keldysh, Test
     @test backward_branch ∉ c
     @test imaginary_branch ∈ c
   end
+
+  let c = twist(FullContour(tmax=1.0, β=5.0))
+    for ref in [0.0, 0.5, 2.0, 5.0, 5.5, 6.5]
+        @test get_ref(c, get_point(c, ref)) == ref
+        @test get_ref(c, c(ref)) == ref
+    end
+  end
 end


### PR DESCRIPTION
This function is the inverse of `get_point()`: It takes a `BranchPoint` and returns a reference value w.r.t. to a given contour.