### PR TITLE
[test] imtime gf interp

### DIFF
--- a/test/time_gf.jl
+++ b/test/time_gf.jl
@@ -87,3 +87,43 @@ using Keldysh, Test
   end
 
 end
+
+@testset "imtime interpolation" begin
+
+    β = 1.0
+    ntau = 16
+    
+    contour = ImaginaryContour(β=β);
+    grid = ImaginaryTimeGrid(contour, ntau);
+
+    Δ = ImaginaryTimeGF(
+        (t1, t2) -> im * (t1.bpoint.val - t2.bpoint.val)^2,
+        grid, 1, fermionic, true)
+
+    r1, r2 = 0.5, 0.1
+    
+    t1 = get_point(contour, r1)
+    t2 = get_point(contour, r2)
+
+    d_12 = Δ(t1, t2)
+
+    t12 = get_point(contour, r1 - r2)
+    t0 = get_point(contour, 0)
+            
+    d_120 = Δ(t12, t0)
+
+    diff = abs(d_12 - d_120)
+    tol = 1e-12
+    
+    if diff >= tol
+        println("t0  = $t0")
+        println("t12 = $t12")
+        println("t1  = $t1")
+        println("t2  = $t2")
+        println("d_12  = $d_12")
+        println("d_120 = $d_120")
+    end
+    
+    @test diff < tol    
+        
+end


### PR DESCRIPTION
Dear Joseph,

I think there might be a problem with the interpolation for imaginary time Green's functions. The interpolation result seems not to be time-translational invariant. I was expecting that

$$
G(\tau_1, \tau_2) = G(\tau_1 - \tau_2, 0)
$$

In this pull request is a test that checks for this by calling the interpolation routine for the two cases above, comparing the result.

For me the test fails with:

```julia
% j time_gf.jl 
Test Summary: | Pass  Total
time_gf       |    8      8
t0  = BranchPoint(0.0 + 0.0im, 0.0, imaginary_branch)
t12 = BranchPoint(0.0 - 0.4im, 0.4, imaginary_branch)
t1  = BranchPoint(0.0 - 0.5im, 0.5, imaginary_branch)
t2  = BranchPoint(0.0 - 0.1im, 0.1, imaginary_branch)
d_12  = 0.0 - 0.16222222222222224im
d_120 = 0.0 - 0.16000000000000003im
imtime interpolation: Test Failed at /.../dev/Keldysh.jl/test/time_gf.jl:127
  Expression: diff < tol
   Evaluated: 0.0022222222222222088 < 1.0e-12
Stacktrace:
 [1] macro expansion
   @ /.../julia/share/julia/stdlib/v1.7/Test/src/Test.jl:445 [inlined]
 [2] macro expansion
   @ ~/dev/Keldysh.jl/test/time_gf.jl:127 [inlined]
 [3] macro expansion
   @ /.../julia/share/julia/stdlib/v1.7/Test/src/Test.jl:1283 [inlined]
 [4] top-level scope
   @ ~/dev/Keldysh.jl/test/time_gf.jl:93
Test Summary:        | Fail  Total
imtime interpolation |    1      1
ERROR: LoadError: Some tests did not pass: 0 passed, 1 failed, 0 errored, 0 broken.
in expression starting at /.../dev/Keldysh.jl/test/time_gf.jl:91
```

Could this be a bug?

Best, Hugo